### PR TITLE
feat: add d2_oracle_serialize tool to serialize D2 graph into D2 text format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ With the new Oracle API integration, AI assistants can now build and modify diag
 - **d2_oracle_move** - Move shapes between containers
 - **d2_oracle_rename** - Rename diagram elements
 - **d2_oracle_get_info** - Get information about shapes, connections, or containers
+- **d2_oracle_serialize** - Get the current D2 text representation of the diagram
 
 ### Additional Features
 - **20 themes** - Support for all D2 themes (18 light + 2 dark)
@@ -289,6 +290,18 @@ Get information about diagram elements:
 }
 ```
 
+#### d2_oracle_serialize
+
+Get the current D2 text representation of the diagram:
+
+```json
+{
+  "diagram_id": "my-diagram"
+}
+```
+
+Returns the complete D2 text of the diagram including all modifications made through Oracle API.
+
 ### Example Oracle API Workflow
 
 ```javascript
@@ -311,7 +324,10 @@ d2_oracle_create({ diagram_id: "architecture", key: "api -> db" })
 // 5. Reorganize if needed
 d2_oracle_move({ diagram_id: "architecture", key: "api", new_parent: "backend" })
 
-// 6. Export final result
+// 6. Get current D2 text
+d2_oracle_serialize({ diagram_id: "architecture" })
+
+// 7. Export final result
 d2_export({ diagramId: "architecture", format: "svg" })
 ```
 
@@ -396,7 +412,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Changelog
 
-### v0.2.0 (Latest)
+### v0.3.0 (Latest)
+- Added `d2_oracle_serialize` tool to get current D2 text representation
+
+### v0.2.0
 - Added D2 Oracle API integration for incremental diagram manipulation
 - 6 new MCP tools for creating, modifying, and querying diagram elements
 - Support for stateful diagram editing sessions

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,7 @@ const (
 	// ServerName is the name of the MCP server.
 	ServerName = "d2mcp"
 	// ServerVersion is the version of the MCP server.
-	ServerVersion = "0.1.0"
+	ServerVersion = "0.3.0"
 )
 
 func main() {
@@ -88,6 +88,7 @@ func main() {
 	oracleMoveHandler := handler.NewOracleMoveHandler(oracleUseCase)
 	oracleRenameHandler := handler.NewOracleRenameHandler(oracleUseCase)
 	oracleGetHandler := handler.NewOracleGetHandler(oracleUseCase)
+	oracleSerializeHandler := handler.NewOracleSerializeHandler(oracleUseCase)
 
 	// Register tools.
 	if err := server.RegisterTool(renderHandler.GetTool(), renderHandler.GetHandler()); err != nil {
@@ -126,6 +127,9 @@ func main() {
 	}
 	if err := server.RegisterTool(oracleGetHandler.GetTool(), oracleGetHandler.GetHandler()); err != nil {
 		log.Fatalf("Failed to register oracle get tool: %v", err)
+	}
+	if err := server.RegisterTool(oracleSerializeHandler.GetTool(), oracleSerializeHandler.GetHandler()); err != nil {
+		log.Fatalf("Failed to register oracle serialize tool: %v", err)
 	}
 
 	// Start the server.

--- a/internal/presentation/handler/oracle_serialize.go
+++ b/internal/presentation/handler/oracle_serialize.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/i2y/d2mcp/internal/usecase"
+)
+
+// OracleSerializeHandler handles the d2_oracle_serialize tool.
+type OracleSerializeHandler struct {
+	useCase *usecase.OracleUseCase
+}
+
+// NewOracleSerializeHandler creates a new Oracle serialize handler.
+func NewOracleSerializeHandler(useCase *usecase.OracleUseCase) *OracleSerializeHandler {
+	return &OracleSerializeHandler{
+		useCase: useCase,
+	}
+}
+
+// GetTool returns the MCP tool definition.
+func (h *OracleSerializeHandler) GetTool() mcp.Tool {
+	return mcp.NewTool(
+		"d2_oracle_serialize",
+		mcp.WithDescription("Get the current D2 text representation of a diagram being edited with Oracle API"),
+		mcp.WithString("diagram_id", mcp.Description("ID of the diagram to serialize"), mcp.Required()),
+	)
+}
+
+// GetHandler returns the tool handler function.
+func (h *OracleSerializeHandler) GetHandler() server.ToolHandlerFunc {
+	return h.Handle
+}
+
+// Handle processes the serialize request.
+func (h *OracleSerializeHandler) Handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Extract arguments.
+	diagramID := mcp.ParseString(request, "diagram_id", "")
+
+	content, err := h.useCase.SerializeDiagram(ctx, diagramID)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr("Failed to serialize diagram", err), nil
+	}
+
+	return mcp.NewToolResultText(content), nil
+}


### PR DESCRIPTION
 ## What
This PR adds d2_oracle_serialize tool that returns the current D2 text representation of a diagram being edited with D2 Oracle API.

## Why
AI assistants need to show users the current state of their diagrams in D2 format during incremental editing, enabling verification and manual adjustments before final rendering.